### PR TITLE
Fix Content-Length:-1 to 0 in no post fields.

### DIFF
--- a/src/OpenViduClient.php
+++ b/src/OpenViduClient.php
@@ -68,6 +68,11 @@ class OpenViduClient
 					$str_parameters = json_encode($req->parameters);
 					curl_setopt($curl, CURLOPT_POSTFIELDS, $str_parameters);
 				}
+				// empty array gets Content-Length:0
+				else
+				{
+					curl_setopt($curl, CURLOPT_POSTFIELDS, []);
+				}
 
 				break;
 


### PR DESCRIPTION
A POST request that does not set an empty body will be sent with Content-Length: -1.

OpenVidu 2.18.0 returns a 400 Bad Request for requests with Content-Length:-1.

By setting an empty array, Content-Length:0 will be sent and the expected response will be returned.
